### PR TITLE
Fix: Implement WCSession activation and delegate for WatchOS app

### DIFF
--- a/gemini-watch-os Watch App/NotiZenWatchApp.swift
+++ b/gemini-watch-os Watch App/NotiZenWatchApp.swift
@@ -13,12 +13,17 @@ import WatchConnectivity
 @main
 struct NotiZenWatch_Watch_AppApp: App {
     @StateObject private var appState = WatchAppState() // Create and manage the app state
+    private var sessionDelegate = WatchSessionDelegate()
 
     init() {
         // Activate WatchConnectivity early in app lifecycle (watchOS)
         #if canImport(WatchConnectivity)
         if WCSession.isSupported() {
             print("Watch App: Activating WatchConnectivity at launch")
+            // WatchConnectivityManager.shared.activateSession() // Assuming this might fail
+            let session = WCSession.default
+            session.delegate = sessionDelegate
+            session.activate()
         }
         #endif
     }
@@ -30,3 +35,19 @@ struct NotiZenWatch_Watch_AppApp: App {
         }
     }
 }
+
+#if canImport(WatchConnectivity)
+class WatchSessionDelegate: NSObject, WCSessionDelegate {
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        if let error = error {
+            print("Watch App: WCSession activation failed with error: \(error.localizedDescription)")
+            return
+        }
+        print("Watch App: WCSession activated with state: \(activationState.rawValue)")
+    }
+
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        print("Watch App: WCSession reachability changed to: \(session.isReachable)")
+    }
+}
+#endif


### PR DESCRIPTION
The WatchOS app was not activating its WCSession, preventing communication with the iOS app. This change introduces a WatchSessionDelegate class within NotiZenWatchApp.swift and ensures that WCSession.default is activated with this delegate when the WatchOS app launches.

This enables the WatchOS app to establish a communication channel with its iOS counterpart.